### PR TITLE
Add a default funding config

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+github: ["tiki"]


### PR DESCRIPTION
Allows displaying the GitHub Sponsors badge on our profile and repos.
This should be the default for all repos in the org.

Related to #25
