### PR TITLE
Add default branch protections

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -62,3 +62,42 @@ labels:
   - name: duplicate
     color: CFD3D7
     description: This issue or pull request already exists.
+
+branches:
+  - name: main
+    protection:
+      # Settings correspond to the request body for GitHub's "Update branch protection" API:
+      #
+      #   https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection
+      #
+
+      allow_deletions: false
+      allow_force_pushes: false
+      allow_fork_syncing: null # Only applies to fork repos
+      block_creations: true
+      enforce_admins: true
+      lock_branch: false
+      required_conversation_resolution: true
+      required_linear_history: false
+
+      required_status_checks:
+        strict: true
+        contexts: [] # TODO: Add required status checks here
+
+        # According to docs, "contexts" is both deprecated AND required, but checks are going to be
+        # the preferred method going forward. Come back to these. Maybe once we have our own GH Apps.
+        #
+        # checks:
+        #   - app_id: 123456
+        #     context: CHECK-NAME
+
+      required_pull_request_reviews:
+        dismissal_restrictions:
+          teams: ["core-development"]
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        require_last_push_approval: true
+        required_approving_review_count: 1
+        bypass_pull_request_allowances: null
+
+      restrictions: null # Add a list of teams or apps that are permitted to push to the branch


### PR DESCRIPTION
Using the Repository Settings app, define a default set of branch
protections for the main branch. This should be propagated to the
rest of the repos in org after they each get a touch to their individual
settings files.
